### PR TITLE
Wechsel auf getHost()

### DIFF
--- a/lib/parameter_rewrite.php
+++ b/lib/parameter_rewrite.php
@@ -64,7 +64,7 @@ class parameter_rewrite {
 			$articleId = null;
 			$clangId = null;
 			
-			foreach (rex_yrewrite::$paths['paths'][rex_yrewrite::getCurrentDomain()->getName()] as $i_id => $i_cls) {
+            		foreach (rex_yrewrite::$paths['paths'][rex_yrewrite::getHost()] as $i_id => $i_cls) {
 				foreach (rex_clang::getAllIds() as $clang_id) {
 					if (isset($i_cls[$clang_id]) && $i_cls[$clang_id] == $path) {
 						$articleId = $i_id;


### PR DESCRIPTION
getCurrentDomain()->getName() leitet intern nicht in allen szenarien auf die richtigen Domains. In meinem Szenario ist in der Strukturansicht folgendes gegeben:

- Kategorie domain1.de
-- unterkategorieA
-- unterkategorieB
- Kategorie domain2.de
-- unterkategorieC
-- unterkategorieD

Wenn in den YRewriteSettings die Domains korrekt eingestellt sind und auf die jeweilige verweisen, kommt trotzdem immer nur domain1 in $path vor bzw getCurrentDomain()->getName() gibt immer domain1 zurück.

[rex_yrewrite::getHost()] scheint mir zuverlässiger zu sein.